### PR TITLE
Incorrect CSV string formatting in Stat exporter

### DIFF
--- a/runtool/exporters/Stat.py
+++ b/runtool/exporters/Stat.py
@@ -1,27 +1,23 @@
-import cgi
+import csv
 from sea_runtool import GraphCombiner
 
 
 class Stat(GraphCombiner):
     def __init__(self, args, tree):
         GraphCombiner.__init__(self, args, tree)
-        self.file = open(self.get_targets()[-1], "w+b")
-        self.file.write("domain,name,min,max,avg,count\n")
 
     def get_targets(self):
         return [self.args.output + ".csv"]
 
     def finish(self):
         GraphCombiner.finish(self)
-        for domain, data in self.per_domain.iteritems():
-            for task_name, task_data in data['tasks'].iteritems():
-                time = task_data['time']
-                self.file.write('%s,%s,%s,%s,%s,%d\n' % (
-                        cgi.escape(domain), cgi.escape(task_name),
-                        min(time), max(time), sum(time) / len(time), len(time)
-                    )
-                )
-        self.file.close()
+        with open(self.get_targets()[-1], 'w+b') as f:
+            writer = csv.writer(f)
+            writer.writerow(["domain", "name", "min", "max", "avg", "total", "count"])
+            for domain, data in self.per_domain.iteritems():
+                for task_name, task_data in data['tasks'].iteritems():
+                    time = task_data['time']
+                    writer.writerow([domain, task_name, min(time), max(time), sum(time) / len(time), sum(time), len(time)])
 
     @staticmethod
     def join_traces(traces, output, args):  # FIXME: implement real joiner


### PR DESCRIPTION
This fix contains two changes for Stat exporter:
1. The cgi.escape() function does not correctly escape the CSV string if it contains commas.
2. I added a new column to the results table that contains the total time.